### PR TITLE
added --clean option to stacscheck

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+3.2.0 -> 3.2.1
+==============
+
+* Added --clean to clear .class files from source file
+
 3.0.0 -> 3.1.0
 ==============
 

--- a/manuals/quickstart-guide.md
+++ b/manuals/quickstart-guide.md
@@ -14,7 +14,7 @@ stacscheck 3.2.0
 You must give a directory of tests to run!
 ```
 
-If the machine doesn't have it, you can download it from 
+If the machine doesn't have it, you can download it from
 [https://studres.cs.st-andrews.ac.uk/Library/stacscheck/](https://studres.cs.st-andrews.ac.uk/Library/stacscheck/).
 You only need the `stacscheck` script. See [installing stacscheck](installing-stacscheck.md) for more guidance
 on installing `stacscheck` on your own machine.
@@ -39,6 +39,7 @@ Useful options for `stacscheck`:
 *  `--html=FILE` : Output a nice HTML output to FILE
 *  `--version`   : Print out version of checker
 *  `--verbose`   : Output lots of information about how the testing is progressing (probably too much)
+*  `--clean`     : Remove .class files from the source directory after the tests are run
 
 Understanding tests
 -------------------
@@ -47,4 +48,3 @@ If you want to understand what is being tested, go into the tests directory. Eac
 on a shell script (which is a series of commands which can be run)
 
 A full specification on how to read the tests is available [here](specification.html).
-

--- a/stacscheck
+++ b/stacscheck
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-VERSION = "3.2.0"
+VERSION = "3.2.1"
 
 # MIT License
 

--- a/stacscheck
+++ b/stacscheck
@@ -28,6 +28,7 @@ VERSION = "3.2.0"
 import sys
 import signal
 import os
+import glob
 import subprocess
 import re
 import time
@@ -391,7 +392,7 @@ def try_parse_config_file(basedir):
         if not section in ['info', 'version']:
             warn_print("practical.config has an unexpected section: ", section)
             sys.exit(1)
-    
+
     if not 'info' in config.sections():
         warn_print("practical.config does not have an [info] section")
         sys.exit(1)
@@ -594,7 +595,7 @@ def nice_name(name):
 
 # Check if one directory is contained within another
 def in_directory(basedir, childdir):
-    #make both absolute    
+    #make both absolute
     basedir = os.path.join(os.path.realpath(basedir),'')
     childdir = os.path.join(os.path.realpath(childdir), '')
     return os.path.commonprefix([basedir, childdir]) == basedir
@@ -693,7 +694,7 @@ def run_program(program, stdin, extra_env):
     with tempfile.TemporaryDirectory() as scratchdir:
         extra_env["SCRATCHDIR"] = scratchdir
         return run_program_popen(program, stdin, extra_env)
-    
+
 def run_bash_script(script, stdin, extra_env):
     return run_program(["bash", script], stdin, extra_env)
 
@@ -815,7 +816,7 @@ def run_tests_recursive(testdir):
 
                 # Add diff for html to result
                 register_diff_test(result, out)
-        
+
     # Always search in subdirectories
     # Run tests for subdirectories
     try:
@@ -842,7 +843,7 @@ def extract_file_with_submission(archive_name, temp_dir):
     content_list = None
 
     current_path = os.path.abspath(os.getcwd())
-    
+
     # Check that the file specified with --archive exists in cwd
     if not os.path.exists(os.path.join(current_path, ARCHIVE)):
         print("- File not found: " + archive_name);
@@ -889,7 +890,7 @@ def extract_file_with_submission(archive_name, temp_dir):
 ##################################################################
 # Main program
 def run():
-    global VERBOSE, TESTBASE, SUBMISSIONBASE, PARENTBASE, TRYHARDER, ARCHIVE
+    global VERBOSE, TESTBASE, SUBMISSIONBASE, PARENTBASE, TRYHARDER, ARCHIVE, CLEAN
     # parser = argparse.ArgumentParser(usage="%prog [options] testdirectory")
     parser = argparse.ArgumentParser(prog="PROG")
     parser.add_argument("--id", dest="subid", default="<unknown>",
@@ -908,6 +909,8 @@ def run():
     parser.add_argument("--version", action="version", version=VERSION)
     parser.add_argument("--archive", dest="archive",
                       help="Look for .zip/.tar/.tar.gz/.tar.xz submission with given name")
+    parser.add_argument("--clean", action="store_true", dest="clean", default=False,
+                        help="Clean source directory of .class files after running")
     parser.add_argument("testdir")
 
     args = parser.parse_args()
@@ -924,6 +927,7 @@ def run():
     VERBOSE = args.verbose
     TRYHARDER = args.tryharder
     ARCHIVE = args.archive
+    CLEAN = args.clean
 
     if not os.path.exists(args.testdir):
         print("stacscheck " + VERSION)
@@ -1007,6 +1011,14 @@ def run():
                 jsonfile.write("\n")
     except EnvironmentError as e:
         print("Error outputting json: " + str(e))
+
+    # If the clean flag is set clear out class files
+    if CLEAN and SUBMISSIONBASE is not None:
+        for filePath in glob.glob(os.path.join(SUBMISSIONBASE, "*.class")):
+            try:
+                os.remove(filePath);
+            except:
+                print("Error while deleting file: ", filePath);
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added a --clean option to stacscheck that will allow the user to remove .class files from their source directory.  This was added to avoid cluttering up the source folder if the user is separating their bytecode from their source files, as is the case with most build systems.  The changes have no affect if the users do not add the --clean option, and all tests are passing.