### PR TITLE
Fix `html` links in the all students overview

### DIFF
--- a/running-all-students/internal/student_overview
+++ b/running-all-students/internal/student_overview
@@ -66,7 +66,7 @@ JINJAPAGE = """
     <tr>
     <td style="width:18px"> {{ student.subid }} 
     <a href="txt/{{student.subid}}.txt">txt</a> 
-    <a href="txt/{{student.subid}}.html">html</a> </td>
+    <a href="html/{{student.subid}}.html">html</a> </td>
     {%- for name in testnames -%}
     {%- if name in student.dicttests -%}
         {%- if student.dicttests[name].pass -%}


### PR DESCRIPTION
When running stacscheck across all students, the overview's `html` link for each student points to the `txt/<MatricNo>.html`, which is incorrect. Folks seem to either ignore it, work around it by clicking on an individual test (which links correctly), or some might have their own ways of fixing it locally.

In any case, I have fixed the line in the internal script so that the link generation points to `html/<MatricNo>.html`, which should hopefully save a small amount of friction in future outputs.